### PR TITLE
Fixing build on mac x86 64

### DIFF
--- a/code/scrypt-jane-portable-x86.h
+++ b/code/scrypt-jane-portable-x86.h
@@ -249,7 +249,7 @@
 #endif /* X86ASM || X86_64ASM */
 
 
-// #if defined(CPU_X86) || defined(CPU_X86_64)
+#if defined(CPU_X86) || defined(CPU_X86_64)
 
 typedef enum cpu_flags_x86_t {
 	cpu_mmx = 1 << 0,
@@ -264,7 +264,10 @@ typedef enum cpu_flags_x86_t {
 	cpu_avx2 = 1 << 9
 } cpu_flags_x86;
 
-#if 0
+#endif  /* CPU_X86 || CPU_X86_64 */
+
+// FIXME(poszu) The assembly below doesn't compile on x86_64 Mac
+#if (defined(CPU_X86) || defined(CPU_X86_64)) && !defined(OS_OSX)
 
 typedef enum cpu_vendors_x86_t {
 	cpu_nobody,
@@ -468,4 +471,4 @@ detect_cpu(void) {
 	return 0;
 }
 
-#endif /* defined(CPU_X86) || defined(CPU_X86_64) */
+#endif /* (defined(CPU_X86) || defined(CPU_X86_64)) && !defined(OS_OSX) */

--- a/code/scrypt-jane-portable-x86.h
+++ b/code/scrypt-jane-portable-x86.h
@@ -1,5 +1,4 @@
-// #if defined(CPU_X86) && (defined(COMPILER_MSVC) || defined(COMPILER_GCC))
-#if 0
+#if defined(CPU_X86) && (defined(COMPILER_MSVC) || defined(COMPILER_GCC))
 	#define X86ASM
 
 	/* gcc 2.95 royally screws up stack alignments on variables */
@@ -250,7 +249,8 @@
 #endif /* X86ASM || X86_64ASM */
 
 
-#if defined(CPU_X86) || defined(CPU_X86_64)
+// #if defined(CPU_X86) || defined(CPU_X86_64)
+#if 0
 
 typedef enum cpu_flags_x86_t {
 	cpu_mmx = 1 << 0,

--- a/code/scrypt-jane-portable-x86.h
+++ b/code/scrypt-jane-portable-x86.h
@@ -250,7 +250,6 @@
 
 
 // #if defined(CPU_X86) || defined(CPU_X86_64)
-#if 0
 
 typedef enum cpu_flags_x86_t {
 	cpu_mmx = 1 << 0,
@@ -264,6 +263,8 @@ typedef enum cpu_flags_x86_t {
 	cpu_xop = 1 << 8,
 	cpu_avx2 = 1 << 9
 } cpu_flags_x86;
+
+#if 0
 
 typedef enum cpu_vendors_x86_t {
 	cpu_nobody,

--- a/code/scrypt-jane-portable-x86.h
+++ b/code/scrypt-jane-portable-x86.h
@@ -1,4 +1,5 @@
-#if defined(CPU_X86) && (defined(COMPILER_MSVC) || defined(COMPILER_GCC))
+// #if defined(CPU_X86) && (defined(COMPILER_MSVC) || defined(COMPILER_GCC))
+#if 0
 	#define X86ASM
 
 	/* gcc 2.95 royally screws up stack alignments on variables */


### PR DESCRIPTION
It fails to compile the assembly on x86_64 macos. Setting `-no-integrated-as` as suggested in README doesn't help (there is a different error then). 

This PR removes automatic detection of Intel intrinsic for macos. It will run using the slower "basic" algorithm but at least it compiles.

A log from a failed build:
```
running: "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "-m64" "-arch" "x86_64" "-I" "scrypt-jane/code" "-I" "scrypt-jane" "-DSCRYPT_CHACHA" "-DSCRYPT_KECCAK512" "-o" "/Users/runner/work/scrypt-jane-rs/scrypt-jane-rs/target/debug/build/scrypt-jane-sys-c85cef7226aa8f22/out/lib/scrypt-jane/scrypt-jane.o" "-c" "scrypt-jane/scrypt-jane.c"
  cargo:warning=In file included from scrypt-jane/scrypt-jane.c:10:
  cargo:warning=scrypt-jane/code/scrypt-jane-portable.h:139:10: warning: 'ALIGN' macro redefined [-Wmacro-redefined]
  cargo:warning=        #define ALIGN(n) __attribute__((aligned(n)))
  cargo:warning=                ^
  cargo:warning=/Applications/Xcode_14.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/i386/param.h:85:9: note: previous definition is here
  cargo:warning=#define ALIGN(p)        __DARWIN_ALIGN(p)
  cargo:warning=        ^
  cargo:warning=In file included from scrypt-jane/scrypt-jane.c:10:
  cargo:warning=In file included from scrypt-jane/code/scrypt-jane-portable.h:303:
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:313:3: error: unknown token in expression
  cargo:warning=                a2(mov [%1 + 0], eax)
  cargo:warning=                ^
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:185:19: note: expanded from macro 'a2'
  cargo:warning=        #define a2(x, y) GNU_AS2(x, y)
  cargo:warning=                         ^
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:[178](https://github.com/spacemeshos/scrypt-jane-rs/actions/runs/4362513138/jobs/7627492282#step:6:179):24: note: expanded from macro 'GNU_AS2'
  cargo:warning=        #define GNU_AS2(x, y) #x ", " #y ";\n"
  cargo:warning=                              ^
  cargo:warning=<scratch space>:26:2: note: expanded from here
  cargo:warning="mov [%1 + 0]"
  cargo:warning= ^
  cargo:warning=<inline asm>:5:6: note: instantiated into assembly here
  cargo:warning=mov [%rsi + 0], eax;
  cargo:warning=     ^
  cargo:warning=In file included from scrypt-jane/scrypt-jane.c:10:
  cargo:warning=In file included from scrypt-jane/code/scrypt-jane-portable.h:303:
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:314:3: error: unknown token in expression
  cargo:warning=                a2(mov [%1 + 4], ebx)
  cargo:warning=                ^
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:[185](https://github.com/spacemeshos/scrypt-jane-rs/actions/runs/4362513138/jobs/7627492282#step:6:186):19: note: expanded from macro 'a2'
  cargo:warning=        #define a2(x, y) GNU_AS2(x, y)
  cargo:warning=                         ^
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:178:24: note: expanded from macro 'GNU_AS2'
  cargo:warning=        #define GNU_AS2(x, y) #x ", " #y ";\n"
  cargo:warning=                              ^
  cargo:warning=<scratch space>:28:2: note: expanded from here
  cargo:warning="mov [%1 + 4]"
  cargo:warning= ^
  cargo:warning=<inline asm>:6:6: note: instantiated into assembly here
  cargo:warning=mov [%rsi + 4], ebx;
  cargo:warning=     ^
  cargo:warning=In file included from scrypt-jane/scrypt-jane.c:10:
  cargo:warning=In file included from scrypt-jane/code/scrypt-jane-portable.h:303:
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:315:3: error: unknown token in expression
  cargo:warning=                a2(mov [%1 + 8], ecx)
  cargo:warning=                ^
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:185:19: note: expanded from macro 'a2'
  cargo:warning=        #define a2(x, y) GNU_AS2(x, y)
  cargo:warning=                         ^
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:178:24: note: expanded from macro 'GNU_AS2'
  cargo:warning=        #define GNU_AS2(x, y) #x ", " #y ";\n"
  cargo:warning=                              ^
  cargo:warning=<scratch space>:30:2: note: expanded from here
  cargo:warning="mov [%1 + 8]"
  cargo:warning= ^
  cargo:warning=<inline asm>:7:6: note: instantiated into assembly here
  cargo:warning=mov [%rsi + 8], ecx;
  cargo:warning=     ^
  cargo:warning=In file included from scrypt-jane/scrypt-jane.c:10:
  cargo:warning=In file included from scrypt-jane/code/scrypt-jane-portable.h:303:
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:316:3: error: unknown token in expression
  cargo:warning=                a2(mov [%1 + 12], edx)
  cargo:warning=                ^
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:185:19: note: expanded from macro 'a2'
  cargo:warning=        #define a2(x, y) GNU_AS2(x, y)
  cargo:warning=                         ^
  cargo:warning=scrypt-jane/code/scrypt-jane-portable-x86.h:178:24: note: expanded from macro 'GNU_AS2'
  cargo:warning=        #define GNU_AS2(x, y) #x ", " #y ";\n"
  cargo:warning=                              ^
  cargo:warning=<scratch space>:32:2: note: expanded from here
  cargo:warning="mov [%1 + 12]"
  cargo:warning= ^
  cargo:warning=<inline asm>:8:6: note: instantiated into assembly here
  cargo:warning=mov [%rsi + 12], edx;
  cargo:warning=     ^
  cargo:warning=1 warning and 4 errors generated.
  exit status: 1

  --- stderr


  error occurred: Command "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "-m64" "-arch" "x86_64" "-I" "scrypt-jane/code" "-I" "scrypt-jane" "-DSCRYPT_CHACHA" "-DSCRYPT_KECCAK512" "-o" "/Users/runner/work/scrypt-jane-rs/scrypt-jane-rs/target/debug/build/scrypt-jane-sys-c85cef7[226](https://github.com/spacemeshos/scrypt-jane-rs/actions/runs/4362513138/jobs/7627492282#step:6:227)aa8f22/out/lib/scrypt-jane/scrypt-jane.o" "-c" "scrypt-jane/scrypt-jane.c" with args "cc" did not execute successfully (status code exit status: 1).
```